### PR TITLE
smaller images

### DIFF
--- a/airflow-worker/Dockerfile
+++ b/airflow-worker/Dockerfile
@@ -39,8 +39,7 @@ USER airflow
 EXPOSE 9876
 
 #Python Package Dependencies for Airflow
-RUN pip install --user -r /tmp/requirements.txt
-
+RUN pip install --user -r /tmp/requirements.txt && pip cache purge
 COPY dags/* ${AIRFLOW_HOME}/dags/
 COPY spark_apps/* ${AIRFLOW_HOME}/spark_apps/
 

--- a/airflow/Dockerfile
+++ b/airflow/Dockerfile
@@ -52,7 +52,7 @@ COPY airflow/build/config/webserver_config.py $SRC_HOME/webserver_config.py
 COPY airflow/build/requirements.txt /tmp/requirements.txt
 
 #Python Package Dependencies for Airflow
-RUN pip install --user -r /tmp/requirements.txt
+RUN pip install --user -r /tmp/requirements.txt && pip cache purge
 
 COPY dags/* ${AIRFLOW_HOME}/dags/
 COPY spark_apps/* ${AIRFLOW_HOME}/spark_apps/


### PR DESCRIPTION
Removed pip cache to reduce image sizes

## Description
Saved 0.5 GB (compressed) in airflow and 0.34GB (compressed) in airflow-worker

## Motivation and Context
Smaller images is better

## Dependencies
None

## How Has This Been Tested?
N/A

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/22605641/121545572-a6978980-c9d8-11eb-8ab7-a971ac9bc026.png)

![image](https://user-images.githubusercontent.com/22605641/121545612-ad260100-c9d8-11eb-9100-f836a9922b6a.png)


## Changelog Inclusions

<!-- Text Entered in these sections will appear as it is written, MD formatted -->
<!-- Avoid using the # character as the first character on any line, a trim is -->
<!-- performed on each line when checking for markdown section tags -->
- base feature note
  - **BREAKING** note on base feature
  - Basically whatever formatting we have here, just plain-text
	%> command example
- next feature
  - note on next feature
<!-- If there is NO text in a section, no entries will be collected for that section -->

### Additions

### Changes

### Fixes

### Deprecated

### Removed

### Breaking Changes
